### PR TITLE
Add release-upgrade workflow and share version-diff scripts

### DIFF
--- a/.github/workflows/update-flake.yml
+++ b/.github/workflows/update-flake.yml
@@ -30,19 +30,7 @@ jobs:
     - name: Capture package versions (before)
       env:
         USER: runner
-      run: |
-        nix eval --impure --system aarch64-darwin --json \
-          '.#darwinConfigurations.macos.config' \
-          --apply '
-            cfg:
-              let
-                user = builtins.getEnv "USER";
-                homePkgs = cfg.home-manager.users.${user}.home.packages or [];
-                sysPkgs = cfg.environment.systemPackages or [];
-              in
-                map (p: { name = p.pname or p.name or "unknown"; version = p.version or ""; })
-                    (homePkgs ++ sysPkgs)
-          ' > /tmp/packages-before.json
+      run: bash scripts/nix-capture-versions.sh /tmp/packages-before.json
 
     - name: Update flake.lock
       uses: DeterminateSystems/update-flake-lock@834c491b2ece4de0bbd00d85214bb5e83b4da5c6 # v28
@@ -76,80 +64,10 @@ jobs:
     - name: Capture package versions (after)
       env:
         USER: runner
-      run: |
-        nix eval --impure --system aarch64-darwin --json \
-          '.#darwinConfigurations.macos.config' \
-          --apply '
-            cfg:
-              let
-                user = builtins.getEnv "USER";
-                homePkgs = cfg.home-manager.users.${user}.home.packages or [];
-                sysPkgs = cfg.environment.systemPackages or [];
-              in
-                map (p: { name = p.pname or p.name or "unknown"; version = p.version or ""; })
-                    (homePkgs ++ sysPkgs)
-          ' > /tmp/packages-after.json
+      run: bash scripts/nix-capture-versions.sh /tmp/packages-after.json
 
     - name: Generate version diff
-      run: |
-        jq -s '
-          (.[0] | map({key: .name, value: .version}) | from_entries) as $before
-          | (.[1] | map({key: .name, value: .version}) | from_entries) as $after
-          | {
-              updated: [
-                ($before | keys_unsorted[]) as $k
-                | select($after[$k] != null and $before[$k] != $after[$k])
-                | {name: $k, before: $before[$k], after: $after[$k]}
-              ],
-              added: [
-                ($after | keys_unsorted[]) as $k
-                | select($before[$k] == null)
-                | {name: $k, version: $after[$k]}
-              ],
-              removed: [
-                ($before | keys_unsorted[]) as $k
-                | select($after[$k] == null)
-                | {name: $k, version: $before[$k]}
-              ]
-            }
-        ' /tmp/packages-before.json /tmp/packages-after.json > /tmp/diff.json
-
-        {
-          echo "## Package version changes"
-          echo ""
-
-          UPDATED_COUNT=$(jq '.updated | length' /tmp/diff.json)
-          ADDED_COUNT=$(jq '.added | length' /tmp/diff.json)
-          REMOVED_COUNT=$(jq '.removed | length' /tmp/diff.json)
-
-          if [ "$UPDATED_COUNT" = "0" ] && [ "$ADDED_COUNT" = "0" ] && [ "$REMOVED_COUNT" = "0" ]; then
-            echo "_No user-facing package version changes._"
-          else
-            if [ "$UPDATED_COUNT" != "0" ]; then
-              echo "### Updated ($UPDATED_COUNT)"
-              echo ""
-              echo "| Package | Before | After |"
-              echo "|---------|--------|-------|"
-              jq -r '.updated[] | "| `\(.name)` | \(.before) | \(.after) |"' /tmp/diff.json
-              echo ""
-            fi
-            if [ "$ADDED_COUNT" != "0" ]; then
-              echo "### Added ($ADDED_COUNT)"
-              echo ""
-              jq -r '.added[] | "- `\(.name)` \(.version)"' /tmp/diff.json
-              echo ""
-            fi
-            if [ "$REMOVED_COUNT" != "0" ]; then
-              echo "### Removed ($REMOVED_COUNT)"
-              echo ""
-              jq -r '.removed[] | "- `\(.name)` \(.version)"' /tmp/diff.json
-              echo ""
-            fi
-          fi
-        } > /tmp/diff.md
-
-        echo "--- Generated diff ---"
-        cat /tmp/diff.md
+      run: bash scripts/nix-version-diff.sh /tmp/packages-before.json /tmp/packages-after.json /tmp/diff.md
 
     - name: Post version diff comment
       env:

--- a/.github/workflows/upgrade-nixpkgs-release.yml
+++ b/.github/workflows/upgrade-nixpkgs-release.yml
@@ -1,0 +1,108 @@
+name: Upgrade nixpkgs Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      release:
+        description: "Target nixpkgs/nix-darwin/home-manager release (e.g. 26.05)"
+        required: true
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  upgrade:
+    runs-on: ubuntu-latest
+
+    env:
+      RELEASE: ${{ inputs.release }}
+      BRANCH: upgrade-nixpkgs-${{ inputs.release }}
+
+    steps:
+    - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+      id: app-token
+      with:
+        app-id: ${{ vars.APP_ID }}
+        private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+    - name: Checkout repository
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        token: ${{ steps.app-token.outputs.token }}
+
+    - name: Install Nix
+      uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
+
+    - name: Capture package versions (before)
+      env:
+        USER: runner
+      run: bash scripts/nix-capture-versions.sh /tmp/packages-before.json
+
+    - name: Bump release refs and update flake.lock
+      run: |
+        sed -E -i \
+          "s#(nixos|nix-darwin|release)-[0-9]+\.[0-9]+#\1-${RELEASE}#g" \
+          flake.nix
+        echo "--- flake.nix inputs after bump ---"
+        grep -E 'url = "github:' flake.nix
+        nix flake update
+
+    - name: Check for changes
+      id: changes
+      run: |
+        if git diff --quiet flake.nix flake.lock; then
+          echo "changed=false" >> "$GITHUB_OUTPUT"
+          echo "No changes after bumping to ${RELEASE}; nothing to do."
+        else
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Capture package versions (after)
+      if: steps.changes.outputs.changed == 'true'
+      env:
+        USER: runner
+      run: bash scripts/nix-capture-versions.sh /tmp/packages-after.json
+
+    - name: Generate version diff
+      if: steps.changes.outputs.changed == 'true'
+      run: bash scripts/nix-version-diff.sh /tmp/packages-before.json /tmp/packages-after.json /tmp/diff.md
+
+    - name: Create pull request
+      if: steps.changes.outputs.changed == 'true'
+      env:
+        GH_TOKEN: ${{ steps.app-token.outputs.token }}
+      run: |
+        git config user.name "github-actions[bot]"
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+        git switch -C "$BRANCH"
+        git add flake.nix flake.lock
+        git commit -m "chore: upgrade nixpkgs release to ${RELEASE}"
+        git push --force-with-lease origin "$BRANCH"
+
+        {
+          echo "## Release upgrade to ${RELEASE}"
+          echo ""
+          echo "Bumped the following flake inputs to the \`${RELEASE}\` release branch:"
+          echo "- \`nixpkgs\` -> \`nixos-${RELEASE}\`"
+          echo "- \`nix-darwin\` -> \`nix-darwin-${RELEASE}\`"
+          echo "- \`home-manager\` -> \`release-${RELEASE}\`"
+          echo ""
+          echo "> A release upgrade changes almost every package version, so the table below is large."
+          echo ""
+          cat /tmp/diff.md
+        } > /tmp/pr-body.md
+
+        PR_NUMBER=$(gh pr list --head "$BRANCH" --json number --jq '.[0].number')
+        if [ -n "$PR_NUMBER" ]; then
+          gh pr edit "$PR_NUMBER" --body-file /tmp/pr-body.md
+        else
+          gh pr create \
+            --base "${{ github.ref_name }}" \
+            --head "$BRANCH" \
+            --title "chore: upgrade nixpkgs release to ${RELEASE}" \
+            --label dependencies \
+            --body-file /tmp/pr-body.md \
+            --reviewer mataku
+        fi

--- a/scripts/nix-capture-versions.sh
+++ b/scripts/nix-capture-versions.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -euo pipefail
+
+OUTPUT="${1:?usage: nix-capture-versions.sh <output.json>}"
+
+nix eval --impure --system aarch64-darwin --json \
+  '.#darwinConfigurations.macos.config' \
+  --apply '
+    cfg:
+      let
+        user = builtins.getEnv "USER";
+        homePkgs = cfg.home-manager.users.${user}.home.packages or [];
+        sysPkgs = cfg.environment.systemPackages or [];
+      in
+        map (p: { name = p.pname or p.name or "unknown"; version = p.version or ""; })
+            (homePkgs ++ sysPkgs)
+  ' > "$OUTPUT"

--- a/scripts/nix-version-diff.sh
+++ b/scripts/nix-version-diff.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+set -euo pipefail
+
+BEFORE="${1:?usage: nix-version-diff.sh <before.json> <after.json> <output.md>}"
+AFTER="${2:?usage: nix-version-diff.sh <before.json> <after.json> <output.md>}"
+OUTPUT="${3:?usage: nix-version-diff.sh <before.json> <after.json> <output.md>}"
+
+DIFF_JSON="$(mktemp)"
+
+jq -s '
+  (.[0] | map({key: .name, value: .version}) | from_entries) as $before
+  | (.[1] | map({key: .name, value: .version}) | from_entries) as $after
+  | {
+      updated: [
+        ($before | keys_unsorted[]) as $k
+        | select($after[$k] != null and $before[$k] != $after[$k])
+        | {name: $k, before: $before[$k], after: $after[$k]}
+      ],
+      added: [
+        ($after | keys_unsorted[]) as $k
+        | select($before[$k] == null)
+        | {name: $k, version: $after[$k]}
+      ],
+      removed: [
+        ($before | keys_unsorted[]) as $k
+        | select($after[$k] == null)
+        | {name: $k, version: $before[$k]}
+      ]
+    }
+' "$BEFORE" "$AFTER" > "$DIFF_JSON"
+
+{
+  echo "## Package version changes"
+  echo ""
+
+  UPDATED_COUNT=$(jq '.updated | length' "$DIFF_JSON")
+  ADDED_COUNT=$(jq '.added | length' "$DIFF_JSON")
+  REMOVED_COUNT=$(jq '.removed | length' "$DIFF_JSON")
+
+  if [ "$UPDATED_COUNT" = "0" ] && [ "$ADDED_COUNT" = "0" ] && [ "$REMOVED_COUNT" = "0" ]; then
+    echo "_No user-facing package version changes._"
+  else
+    if [ "$UPDATED_COUNT" != "0" ]; then
+      echo "### Updated ($UPDATED_COUNT)"
+      echo ""
+      echo "| Package | Before | After |"
+      echo "|---------|--------|-------|"
+      jq -r '.updated[] | "| `\(.name)` | \(.before) | \(.after) |"' "$DIFF_JSON"
+      echo ""
+    fi
+    if [ "$ADDED_COUNT" != "0" ]; then
+      echo "### Added ($ADDED_COUNT)"
+      echo ""
+      jq -r '.added[] | "- `\(.name)` \(.version)"' "$DIFF_JSON"
+      echo ""
+    fi
+    if [ "$REMOVED_COUNT" != "0" ]; then
+      echo "### Removed ($REMOVED_COUNT)"
+      echo ""
+      jq -r '.removed[] | "- `\(.name)` \(.version)"' "$DIFF_JSON"
+      echo ""
+    fi
+  fi
+} > "$OUTPUT"
+
+rm -f "$DIFF_JSON"
+
+echo "--- Generated diff ---"
+cat "$OUTPUT"


### PR DESCRIPTION
- extract inline nix eval and jq diff logic into scripts/nix-capture-versions.sh and scripts/nix-version-diff.sh
- refactor update-flake.yml to call the shared scripts
- add upgrade-nixpkgs-release.yml: workflow_dispatch bumps the three release-pinned inputs (nixpkgs, nix-darwin, home-manager) in flake.nix, runs nix flake update, and opens a PR with the package version diff